### PR TITLE
Extensible Enumerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,35 @@
 # Enumerific Enums
 
-The `enumerific` library provides several useful extensions to the Python built-in `enums` library.
+The Enumerific library provides a greenfield implementation of enumerations with many unique features through the library's own `Enumeration` class, as well as separately offering several useful extra methods for the built-in standard library `enums.Enum` type.
+
+The Enumerific library's `Enumeration` class offers the following features:
+
+ * A greenfield implementation of enumerations compatible with Python 3.10 and later versions;
+ * Enumerific enumerations can hold option values of the same or mixed types, including `int`, `float`, `complex`, `str`, `bytes`, `set`, `tuple`, `list`, `dict` as well as arbitrary `object` types;
+ * Enumerific enumeration options can be accessed directly as native data types and enumeration options can be used anywhere that the corresponding native data types can be used;
+ * Support for automatic typecasting of the `Enumeration` base class to support the use of enumeration option values interchangeably with native data type values;
+ * Enumerific enumerations options can be added after an `Enumeration` class has been created either through extending an existing enumerations class through subclassing or by registering new options directly on an existing enumerations class via the `.register()` method; this is especially useful for cases where enumeration options may not be known before runtime;
+ * Enumerific enumerations options can be removed after an `Enumeration` class has been created via the `.unregister()` method; this specialised behaviour is prevented by default, but can be enabled for advanced use cases;
+ * Enforcement of unique values for all options within an enumeration, unless overridden;
+ * Support for aliasing enumeration options;
+ * Support for redefining enumeration options;
+ * Support for automatically generating unique number sequences for enumeration options, including powers of two for bitwise enumeration flags, as well as other sequences such as powers of other numbers and factoring;
+ * Support for annotating enumeration options with additional arbitrary key-value pairs, which can be particularly useful for associating additional data with a given enumeration option, which may be accessed later anywhere in code that the enumeration option is available;
+ * Simple one-line reconciliation of `Enumeration` class options to the corresponding `enums.Enum` class instance that represents the corresponding option; reconciliation by enumeration option name, value and enumeration class instance reference are all supported through the `.reconcile()` class method;
+ * Simple one-line validation of `Enumeration` class options; validation by enumeration option name, value and enumeration class instance reference are all supported through the `.validate()` class method;
+ * Simple access to all of the options provided by an `Enumeration` class instance through the `.options()` class method;
+ * Access to all of the names of the `Enumeration` class options via the `.names()` method;
+ * Access to all of the names/keys of the `Enumeration` class options via the `.keys()` method;
+ * Access to all of the values of the `Enumeration` class options via the `.values()` method;
+ * Access to all of the key-value pairs of the `Enumeration` class options via the `.items()` method;
+ * Ability to determine if an enumeration option is an alias of another option, or is an option in its own right via the `Enumeration` class' `.aliased` property.
+ * Ability to obtain the aliases for an enumeration option via the `.aliases` property.
+
+Furthermore, as noted, the Enumerific library also offers extended functionality for the built-in standard library `enums.Enum` type:
+
+ * Simple one-line reconciliation of `enums.Enum` options to the corresponding `enums.Enum` class instance that represents the corresponding option; reconciliation by enumeration option name, value and enumeration class instance reference are all supported through the `.reconcile()` class method;
+ * Simple one-line validation of `enums.Enum` options; validation by enumeration option name, value and enumeration class instance reference are all supported through the `.validate()` class method;
+ * Simple access to all of the options provided by an `enums.Enum` class instance through the `.options()` class method.
 
 ### Requirements
 
@@ -18,29 +47,603 @@ by entering the following command, and following any prompts:
 
 ### Usage
 
-To use the Enumerific library, simply import the library and use it like you would the built-in `enum` library as a drop-in replacement:
+To use the Enumerific library's implementation of enumerations import the `Enumeration` class from the Enumerific library:
 
 ```python
-from enumerific import Enum
+from enumerific import Enumeration
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
 
-val = MyEnum.Option1
+assert issubclass(Colors, Enumeration)
+
+# Note that as all of the Colors enumeration options have integer values, the class was
+# typecast to int so that its option values can be used interchangeably with integers:
+assert issubclass(Colors, int)
+
+color = Colors.RED
+
+# Enumeration class options are instances of the class
+assert isinstance(color, Colors)
+
+# They can also be instances of the raw value that was assigned to the option
+assert isinstance(color, int)
+
+# Each enumeration class option has a name (the name used to define the option)
+assert color.name == "RED"
+
+# Each enumeration class option has a value (the value used when defining the option)
+assert color.value == 1
+
+# The identity of an enumeration option matches the option
+assert color is Colors.RED
+
+# The equality of an enumeration option can also be compared against the enumeration
+# option directly, against the name of the option, or against the value:
+assert color == Colors.RED
+assert color == "RED"
+assert color == 1
+assert color != 2
 ```
 
-Alternatively, to make use of the extra functionality for the standard library's `Enum`
-class, import the `Enum` class from the Enumerific library:
+#### Example 1: Reconciling a Value
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+# Given a string value in this case
+value = 1
+
+# Reconcile it to the associated enumeration option
+color = Colors.reconcile(value)
+
+assert color == Colors.RED  # asserts successfully
+assert color is Colors.RED  # asserts successfully as Enumeration class options are singletons
+```
+
+#### Example 2: Reconciling an Enumeration Option Name
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+# Given a string value in this case
+value = "RED"
+
+# Reconcile it to the associated enumeration option
+color = Colors.reconcile(value)
+
+assert color == Colors.RED  # asserts successfully
+assert color is Colors.RED  # asserts successfully as Enumeration class options are singletons
+
+# Given a string value in this case
+value = "red"
+
+# Reconcile it to the associated enumeration option;
+# values can be reconciled caselessly too:
+color = Colors.reconcile(value, caselessly=True)
+
+assert color == Colors.RED  # asserts successfully
+assert color is Colors.RED  # asserts successfully as Enumeration class options are singletons
+```
+
+#### Example 3: Validating a Value
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+# The value can be an enumeration option's name, its value, or the enumeration option
+value = "RED"
+value = 1
+value = Colors.RED
+
+if Colors.validate(value) is True:
+    # do something if the value could be validated
+    pass
+else:
+    # do something else if the value could not be validated
+    pass
+```
+
+#### Example 4: Iterating Over Enumeration Options
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+options = Colors.options()
+
+for name, option in options.items():
+    # do something with each option
+    print(option.name, option.value)
+```
+
+#### Example 5: Iterating Over Enumeration Names
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+for name in Colors.names():
+    # do something with each option name
+    print(name)
+```
+
+#### Example 6: Iterating Over Enumeration Keys
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+for key in Colors.keys():
+    # do something with each option key
+    print(key)
+```
+
+#### Example 7: Iterating Over Enumeration Values
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+for value in Colors.values():
+    # do something with each option key
+    print(value)
+```
+
+#### Example 8: Registering New Option
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+Colors.register("PURPLE", 4)
+
+assert "PURPLE" in Colors
+assert Colors.PURPLE.name == "PURPLE"
+assert Colors.PURPLE.value == 4
+assert Colors.PURPLE == 4
+```
+
+#### Example 9: Subclassing
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+class MoreColors(Colors):
+    PURPLE = 4
+    GOLD = 5
+
+assert "BLUE" in Colors
+assert Colors.BLUE.name == "BLUE"
+assert Colors.BLUE.value == 3
+assert Colors.BLUE == 3
+
+assert "PURPLE" in MoreColors
+assert MoreColors.PURPLE.name == "PURPLE"
+assert MoreColors.PURPLE.value == 4
+assert MoreColors.PURPLE == 4
+
+assert "GOLD" in Colors
+assert Colors.GOLD.name == "GOLD"
+assert Colors.GOLD.value == 5
+assert Colors.GOLD == 5
+```
+
+#### Example 10: Subclassing Over
+
+```python
+from enumerific import Enumeration
+
+class Colors(Enumeration):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+# Subclassed Enumerations can have the same name as the parent class
+# The subclass will inherit the enumeration options of its parent
+class Colors(Colors):
+    PURPLE = 4
+    GOLD = 5
+
+assert "BLUE" in Colors
+assert Colors.BLUE.name == "BLUE"
+assert Colors.BLUE.value == 3
+assert Colors.BLUE == 3
+
+assert "PURPLE" in Colors
+assert Colors.PURPLE.name == "PURPLE"
+assert Colors.PURPLE.value == 4
+assert Colors.PURPLE == 4
+
+assert "GOLD" in Colors
+assert Colors.GOLD.name == "GOLD"
+assert Colors.GOLD.value == 5
+assert Colors.GOLD == 5
+```
+
+#### Example 11: Unregistering Existing Option
+
+```python
+from enumerific import Enumeration
+
+# Note that unregistering options is prevented by default; to all options to be removed
+# the `removable` argument needs to be set to `True` when the class is created:
+class Colors(Enumeration, removable=True):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+Colors.unregister("GREEN")
+
+assert "RED" in Colors
+assert "GREEN" not in Colors
+assert "BLUE" in Colors
+```
+
+#### Example 12: Aliasing Options
+
+```python
+from enumerific import Enumeration
+
+# Note that aliasing options is prevented by default to ensure that all options have
+# unique values; to allow aliasing, the `aliased` argument needs to be set to `True`
+# when the class is created; aliases can be added by referencing the original option's
+# name or its value as demonstrated below with the ROUGE and VERTE aliases:
+class Colors(Enumeration, aliased=True):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+    ROUGE = RED
+    VERTE = 2
+
+assert "RED" in Colors
+assert "GREEN" in Colors
+assert "BLUE" in Colors
+assert "ROUGE" in Colors
+assert "VERTE" in Colors
+
+# Note that aliases are just different names for the same exact option, so the aliases
+# can be used interchangeably with the original option, and they have the same identity:
+assert Colors.RED is Colors.ROUGE
+assert Colors.GREEN is Colors.VERTE
+
+# All of the other properties of aliased options are also identical because the alias is
+# just another reference to the same exact object in memory:
+assert Colors.RED.name == Colors.ROUGE.name
+assert Colors.RED.value == Colors.ROUGE.value
+
+# Different options have their own distinct identities
+assert not Colors.RED is Colors.VERTE
+
+# Aliased options report that they have been aliased:
+assert Colors.RED.aliased is True
+assert Colors.GREEN.aliased is True
+assert Colors.ROUGE.aliased is True
+assert Colors.VERTE.aliased is True
+
+# Non-aliased options do not report that they have been aliased:
+assert Colors.BLUE.aliased is False
+
+# The aliases for an option can be obtained via the .aliases property:
+assert Colors.RED.aliases == [Colors.ROUGE]
+assert Colors.GREEN.aliases == [Colors.VERTE]
+assert Colors.BLUE.aliases == []  # BLUE has not been aliased
+```
+
+#### Example 13: Non-Unique Options
+
+```python
+from enumerific import Enumeration
+
+# Note that non-unique options are prevented by default to ensure that all options have
+# unique values; to allow non-unique option values, the `unique` argument needs to be
+# set to `False` when the class is created:
+class Colors(Enumeration, unique=False):
+    RED = 1
+    GREEN = 1
+    BLUE = 3
+
+assert "RED" in Colors
+assert Colors.RED.name == "RED"
+assert Colors.RED.value == 1
+assert Colors.RED == 1
+
+assert "GREEN" in Colors
+assert Colors.GREEN.name == "GREEN"
+assert Colors.GREEN.value == 1
+assert Colors.GREEN == 1
+
+assert "BLUE" in Colors
+assert Colors.BLUE.name == "BLUE"
+assert Colors.BLUE.value == 3
+assert Colors.BLUE == 3
+
+# Note that although options can use the same values when the class has been configured
+# to allow it, the enumeration options still maintain their own distinct identities:
+assert not Colors.RED is Colors.GREEN
+assert not Colors.BLUE is Colors.RED
+
+# However, when enumeration options share values, options with the same values will
+# compare as equal via equality checking (which is different than identity checking):
+assert Colors.RED == Colors.GREEN
+assert Colors.BLUE != Colors.RED
+```
+
+#### Example 14: Bit Wise Flags
+
+```python
+from enumerific import Enumeration
+
+class Permissions(Enumeration, flags=True):
+    READ = 1
+    WRITE = 2
+    EXECUTE = 4
+    DELETE = 8
+
+assert "READ" in Permissions
+assert Permissions.READ.name == "READ"
+assert Permissions.READ.value == 1
+assert Permissions.READ == 1
+
+assert "WRITE" in Permissions
+assert Permissions.WRITE.name == "WRITE"
+assert Permissions.WRITE.value == 2
+assert Permissions.WRITE == 2
+
+assert "EXECUTE" in Permissions
+assert Permissions.EXECUTE.name == "EXECUTE"
+assert Permissions.EXECUTE.value == 4
+assert Permissions.EXECUTE == 4
+
+# OR (add/merge) the READ and WRITE permission flags into the 'permissions' variable
+permissions = Permissions.READ | Permissions.WRITE
+
+assert str(permissions) == "Permissions.READ|WRITE"
+assert Permissions.READ in permissions
+assert Permissions.WRITE in permissions
+assert not Permissions.EXECUTE in permissions
+
+# Raises an exception as DELETE doesn't exist
+assert not Permissions.DELETE in permissions
+
+assert (permissions & Permissions.READ) == Permissions.READ
+assert (permissions & Permissions.WRITE) == Permissions.WRITE
+
+# XOR (remove) the WRITE permission from the 'permissions' variable
+permissions = permissions ^ Permissions.WRITE
+
+assert Permissions.READ in permissions
+assert not Permissions.WRITE in permissions
+assert not Permissions.EXECUTE in permissions
+
+assert (permissions & Permissions.READ) == Permissions.READ
+assert not (permissions & Permissions.WRITE) == Permissions.WRITE
+
+assert not Permissions.WRITE in permissions
+assert str(permissions) == "Permissions.READ"
+
+# The order of the name components always follows the order that the underlaying flags were derived
+assert str(Permissions.READ | Permissions.WRITE) == "Permissions.READ|WRITE"
+assert str(Permissions.WRITE | Permissions.READ) == "Permissions.READ|WRITE"
+assert (
+    str(Permissions.WRITE | Permissions.READ | Permissions.EXECUTE)
+    == "Permissions.READ|WRITE|EXECUTE"
+)
+
+# Assign 'permissions' to the (~) inverse (opposite) of EXECUTE,
+# i.e. all Permissions options except EXECUTE
+permissions = ~Permissions.EXECUTE
+
+assert Permissions.READ in permissions
+assert Permissions.WRITE in permissions
+assert not Permissions.EXECUTE in permissions
+assert Permissions.DELETE in permissions
+assert str(permissions) == "Permissions.READ|WRITE|DELETE"
+```
+
+#### Example 15: Annotating Enumeration Option Values
+
+```python
+from enumerific import Enumeration, anno
+
+# The 'anno' (annotation) class can be used to add annotations to enumeration options;
+# these are arbitrary key-value pairs that can be used to hold any additional data that
+# is useful to keep associated with the enumeration option; the annotation values are
+# then accessible anywhere that the enumeration is, and can be accessed as attributes:
+class Colors(Enumeration):
+    RED = anno(1, rgb=(255, 0, 0), primary=True)
+    GREEN = anno(2, rgb=(0, 255, 0), primary=True)
+    BLUE = anno(3, rgb=(0, 0, 255), primary=True)
+    PURPLE = anno(4, rgb=(255, 0, 255), primary=False)
+
+assert "RED" in Colors
+assert Colors.RED.name == "RED"
+assert Colors.RED.value == 1
+assert Colors.RED == 1
+assert Colors.RED.rgb == (255, 0, 0)
+assert Colors.RED.primary is True
+
+assert "GREEN" in Colors
+assert Colors.GREEN.name == "GREEN"
+assert Colors.GREEN.value == 2
+assert Colors.GREEN == 2
+assert Colors.GREEN.rgb == (0, 255, 0)
+assert Colors.GREEN.primary is True
+
+assert "BLUE" in Colors
+assert Colors.BLUE.name == "BLUE"
+assert Colors.BLUE.value == 3
+assert Colors.BLUE == 3
+assert Colors.BLUE.rgb == (0, 0, 255)
+assert Colors.BLUE.primary is True
+
+assert "PURPLE" in Colors
+assert Colors.PURPLE.name == "PURPLE"
+assert Colors.PURPLE.value == 4
+assert Colors.PURPLE == 4
+assert Colors.PURPLE.rgb == (255, 0, 255)
+assert Colors.PURPLE.primary is False
+```
+
+#### Example 16: Annotating Enumeration Option Values with Automatic Sequencing
+
+```python
+from enumerific import Enumeration, auto
+
+# The 'auto' (automatic) class can be used to generate unique numeric sequence numbers
+# for enumeration options and to optionally add annotations to those same options; the
+# annotation key-value pairs can be used to hold any additional data that is useful to
+# keep associated with the enumeration option; the annotation values are then accessible
+# anywhere that the enumeration is, and can be accessed as attributes:
+class Colors(Enumeration):
+    RED = auto(rgb=(255, 0, 0), primary=True)
+    GREEN = auto(rgb=(0, 255, 0), primary=True)
+    BLUE = auto(rgb=(0, 0, 255), primary=True)
+    PURPLE = auto(rgb=(255, 0, 255), primary=False)
+
+assert "RED" in Colors
+assert Colors.RED.name == "RED"
+assert Colors.RED.value == 1
+assert Colors.RED == 1
+assert Colors.RED.rgb == (255, 0, 0)
+assert Colors.RED.primary is True
+
+assert "GREEN" in Colors
+assert Colors.GREEN.name == "GREEN"
+assert Colors.GREEN.value == 2
+assert Colors.GREEN == 2
+assert Colors.GREEN.rgb == (0, 255, 0)
+assert Colors.GREEN.primary is True
+
+assert "BLUE" in Colors
+assert Colors.BLUE.name == "BLUE"
+assert Colors.BLUE.value == 3
+assert Colors.BLUE == 3
+assert Colors.BLUE.rgb == (0, 0, 255)
+assert Colors.BLUE.primary is True
+
+assert "PURPLE" in Colors
+assert Colors.PURPLE.name == "PURPLE"
+assert Colors.PURPLE.value == 4
+assert Colors.PURPLE == 4
+assert Colors.PURPLE.rgb == (255, 0, 255)
+assert Colors.PURPLE.primary is False
+```
+
+# Enumerific Library Extended Enumerations: Classes & Methods
+
+The Enumerific library's `Enumeration` class is a greenfield implementation of enumerations
+and does not inherit from any of the standard library enumeration classes, but offers equivalent
+and extended functionality implemented from scratch. Enumerific library enumerations can be used
+in any situation that enumerations are needed, and can replace the use of standard library
+enumerations in almost every case unless some very specific functionality or underlying behaviour
+of standard library enumerations are relied upon in user code. For the majority of cases, the
+functionality is sufficiently equivalent from an application binary interface (ABI) perspective
+that the two implementations can be used interchangeably.
+
+The Enumerific library's extended enumerations module offers the following classes:
+
+ * `EnumerationConfiguration` – The `EnumerationConfiguration` class is used internally by the library
+ to hold configuration information for an `Enumeration` class instance.
+
+ * `EnumerationMetaClass` – The `EnumerationMetaClass` metaclass is responsible for creating instances of the `Enumeration` class for use, and provides an interface between the class definition and some of the special behaviours needed to facilitate enumerations, such as each enumeration option being an instance of the enumeration class.
+
+ * `Enumeration` – The `Enumeration` class is the base class for all Enumerific library extended enumerations; the `Enumeration` class defines shared functionality used by all `Enumeration` class instances.
+
+ * `EnumerationType` – The `EnumerationType` class is actually a subclass of `Enumeration` and is used internally by the library to track the data type of the options assigned to an enumeration class.
+
+ * `EnumerationInteger` – The `EnumerationInteger` class is a subclass of `int` and `Enumeration` and supports interacting with enumeration options natively as `int` (integer) data types.
+
+ * `EnumerationFloat` – The `EnumerationFloat` class is a subclass of `float` and `Enumeration` and supports interacting with enumeration options natively as `float` (floating point) data types.
+
+ * `EnumerationComplex` – The `EnumerationComplex` class is a subclass of `complex` and `Enumeration` and supports interacting with enumeration options natively as `complex` (complex number) data types.
+
+ * `EnumerationBytes` – The `EnumerationBytes` class is a subclass of `bytes` and `Enumeration` and supports interacting with enumeration options natively as `bytes` data types.
+
+ * `EnumerationString` – The `EnumerationString` class is a subclass of `str` and `Enumeration` and supports interacting with enumeration options natively as `str` (string) data types.
+
+ * `EnumerationTuple` – The `EnumerationTuple` class is a subclass of `tuple` and `Enumeration` and supports interacting with enumeration options natively as `tuple` data types.
+
+ * `EnumerationSet` – The `EnumerationSet` class is a subclass of `set` and `Enumeration` and supports interacting with enumeration options natively as `set` data types.
+
+ * `EnumerationList` – The `EnumerationList` class is a subclass of `list` and `Enumeration` and supports interacting with enumeration options natively as `list` data types.
+
+ * `EnumerationDictionary` – The `EnumerationDictionary` class is a subclass of `dict` and `Enumeration` and supports interacting with enumeration options natively as `dict` (dictionary) data types.
+
+ * `EnumerationFlag` – The `EnumerationFlag` class is a special subclass of `int` and `Enumeration` and supports interacting with enumeration options natively as `int` (integer) data types and supports bitwise operations on the enumeration options so that enumeration options can be used as bitwise flags.
+
+The extended enumerations module also offers the following classes for annotating enumeration
+options and for automatically generating sequence numbers for annotation options:
+
+ * `anno` – The `anno` class provides support for annotating an enumeration option's value, allowing an enumeration option to carry both a value of any data type, and optional additional annotations of key-value pairs that can be accessed as properties on the annotated enumeration option.
+ 
+ * `auto` – The `auto` class is a subclass of `anno` and provides support both for annotating and enumeration option's value as per the functionality supported by its superclass, and additionally provides support for automatically generating unique number sequences to use for enumeration options, obviating the need to manually assign unique values to each enumeration option; number sequences can be configured to suit a range of needs, including generating number sequences as powers of two, which is particularly useful for the enumeration of bitwise flags as supported by the `EnumerationFlag` subclass.
+
+# Standard Library Enumerations: Classes & Methods
+
+The Enumerific library's own `Enum` class is a subclass of the built-in `enum.Enum` class,
+so all of the built-in functionality of `enum.Enum` is available, as well as several additional class methods:
+
+* `reconcile(value: object, default: Enum = None, raises: bool = False)` (`Enum`) – The `reconcile()` method allows for an enumeration's value or an enumeration option's name to be reconciled against a matching enumeration option. If the provided value can be matched against one of the enumeration's available options, that option will be returned, otherwise there are two possible behaviours: if the `raises` keyword argument has been set to or left as `False` (its default), the value assigned to the `default` keyword argument will be returned, which may be `None` if no default value has been specified; if the `raises` argument has been set to `True` an `EnumValueError` exception will be raised as an alert that the provided value could not be matched. One can also provide an enumeration option as the input value to the `reconcile` method, and these will be validated and returned as-is.
+
+* `validate(value: object)` (`bool`) – The `validate()` method takes the same range of input values as the `reconcile` method, and returns `True` when the provided value can be reconciled against an enumeration option, or `False` otherwise.
+
+* `options()` (`list[Enum]`) – The `options()` method provides easy access to the list of the enumeration's available options.
+
+The benefits of being able to validate and reconcile various input values against an enumeration, include allowing for a controlled vocabulary of options to be checked against, and the ability to convert enumeration values into their corresponding enumeration option. This can be especially useful when working with input data where you need to convert those values to their corresponding enumeration options, and to be able to do so without maintaining boilerplate code to perform the matching and assignment.
+
+To make use of the extra functionality for the standard library's `Enum` class, import the `Enum` class from the Enumerific library:
 
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enum):
+  RED = 1
+  GREEN = 2
 
-val = MyEnum.Option1
+val = Colors.RED
 ```
 
 You can also import the `Enum` class directly from the `enumerific` library and use it directly:
@@ -48,26 +651,18 @@ You can also import the `Enum` class directly from the `enumerific` library and 
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
+class Colors(Enum):
+  RED = 1
 ```
 
-The Enumerific library's own `Enum` class is a subclass of the built-in `enum.Enum` class, so all of the built-in functionality of `enum.Enum` is available, as well as several additional class methods:
-
-* `reconcile(value: object, default: Enum = None, raises: bool = False) -> Enum` – The `reconcile` method allows for an enumeration's value or an enumeration option's name to be reconciled against a matching enumeration option. If the provided value can be matched against one of the enumeration's available options, that option will be returned, otherwise there are two possible behaviours: if the `raises` keyword argument has been set to or left as `False` (its default), the value assigned to the `default` keyword argument will be returned, which may be `None` if no default value has been specified; if the `raises` argument has been set to `True` an `EnumValueError` exception will be raised as an alert that the provided value could not be matched. One can also provide an enumeration option as the input value to the `reconcile` method, and these will be validated and returned as-is.
-* `validate(value: object) -> bool` – The `validate` method takes the same range of input values as the `reconcile` method, and returns `True` when the provided value can be reconciled against an enumeration option, or `False` otherwise.
-* `options() -> list[Enum]` – The `options` method provides easy access to the list of the enumeration's available options.
-
-The benefits of being able to validate and reconcile various input values against an enumeration, include allowing for a controlled vocabulary of options to be checked against, and the ability to convert enumeration values into their corresponding enumeration option. This can be especially useful when working with input data where you need to convert those values to their corresponding enumeration options, and to be able to do so without maintaining boilerplate code to perform the matching and assignment.
-
-Some examples of use include the following code samples, where each make use of the example `MyEnum` class, defined as follows:
+Some examples of use include the following code samples, where each make use of the example `Colors` class, defined as follows:
 
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enum):
+  RED = 1
+  GREEN = 2
 ```
 
 #### Example 1: Reconciling a Value
@@ -75,18 +670,18 @@ class MyEnum(Enum):
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enum):
+  RED = 1
+  GREEN = 2
 
 # Given a string value in this case
-value = "ABC"
+value = 1
 
 # Reconcile it to the associated enumeration option
-value = MyEnum.reconcile(value)
+color = Colors.reconcile(value)
 
-assert value == MyEnum.Option1  # asserts successfully
-assert value is MyEnum.Option1  # asserts successfully as enums are singletons
+assert color == Colors.RED  # asserts successfully
+assert color is Colors.RED  # asserts successfully as enums are singletons
 ```
 
 #### Example 2: Reconciling an Enumeration Option Name
@@ -94,18 +689,18 @@ assert value is MyEnum.Option1  # asserts successfully as enums are singletons
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enum):
+  RED = 1
+  GREEN = 2
 
 # Given a string value in this case
-value = "Option1"
+value = "GREEN"
 
 # Reconcile it to the associated enumeration option
-value = MyEnum.reconcile(value)
+color = Colors.reconcile(value)
 
-assert value == MyEnum.Option1  # asserts successfully
-assert value is MyEnum.Option1  # asserts successfully as enums are singletons
+assert color == Colors.GREEN  # asserts successfully
+assert color is Colors.GREEN  # asserts successfully as enums are singletons
 ```
 
 #### Example 3: Validating a Value
@@ -113,16 +708,16 @@ assert value is MyEnum.Option1  # asserts successfully as enums are singletons
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enum):
+  RED = 1
+  GREEN = 2
 
 # The value can be an enumeration option's name, its value, or the enumeration option
-value = "Option1"
-value = "ABC"
-value = MyEnum.Option1
+value = "RED"
+value = 1
+value = Colors.RED
 
-if MyEnum.validate(value) is True:
+if Colors.validate(value) is True:
     # do something if the value could be validated
     pass
 else:
@@ -135,18 +730,19 @@ else:
 ```python
 from enumerific import Enum
 
-class MyEnum(Enum):
-  Option1 = "ABC"
-  Option2 = "DEF"
+class Colors(Enum):
+  RED = 1
+  GREEN = 2
 
-for option in MyEnum.options():
+for option in Colors.options():
     # do something with each option
     print(option.name, option.value)
 ```
 
 ### Unit Tests
 
-The Enumerific library includes a suite of comprehensive unit tests which ensure that the library functionality operates as expected. The unit tests were developed with and are run via `pytest`.
+The Enumerific library includes a suite of comprehensive unit tests which ensure that the
+library functionality operates as expected. The unit tests were developed with and are run via `pytest`.
 
 To ensure that the unit tests are run within a predictable runtime environment where all of the necessary dependencies are available, a [Docker](https://www.docker.com) image is created within which the tests are run. To run the unit tests, ensure Docker and Docker Compose is [installed](https://docs.docker.com/engine/install/), and perform the following commands, which will build the Docker image via `docker compose build` and then run the tests via `docker compose run` – the output of running the tests will be displayed:
 

--- a/source/enumerific/extensible.py
+++ b/source/enumerific/extensible.py
@@ -203,6 +203,8 @@ class EnumerationConfiguration(object):
     _raises: bool = None
     _flags: bool = None
     _start: int = None
+    _steps: int = None
+    _times: int = None
     _typecast: bool = None
 
     def __init__(
@@ -215,6 +217,8 @@ class EnumerationConfiguration(object):
         raises: bool = None,
         flags: bool = None,
         start: int = None,
+        steps: int = None,
+        times: int = None,
         typecast: bool = None,
     ):
         self.unique = unique
@@ -225,6 +229,8 @@ class EnumerationConfiguration(object):
         self.raises = raises
         self.flags = flags
         self.start = start
+        self.steps = steps
+        self.times = times
         self.typecast = typecast
 
     def __dir__(self) -> list[str]:
@@ -237,6 +243,8 @@ class EnumerationConfiguration(object):
             "raises",
             "flags",
             "start",
+            "steps",
+            "times",
             "typecast",
         ]
 
@@ -373,7 +381,7 @@ class EnumerationConfiguration(object):
         self._flags = flags
 
     @property
-    def start(self) -> bool | None:
+    def start(self) -> int | None:
         return self._start
 
     @start.setter
@@ -385,6 +393,34 @@ class EnumerationConfiguration(object):
                 "The 'start' argument, if specified, must have a positive integer value!"
             )
         self._start = start
+
+    @property
+    def steps(self) -> int | None:
+        return self._steps
+
+    @steps.setter
+    def steps(self, steps: int | None):
+        if steps is None:
+            pass
+        elif not (isinstance(steps, int) and steps >= 0):
+            raise TypeError(
+                "The 'steps' argument, if specified, must have a positive integer value!"
+            )
+        self._steps = steps
+
+    @property
+    def times(self) -> int | None:
+        return self._times
+
+    @times.setter
+    def times(self, times: int | None):
+        if times is None:
+            pass
+        elif not (isinstance(times, int) and times >= 0):
+            raise TypeError(
+                "The 'times' argument, if specified, must have a positive integer value!"
+            )
+        self._times = times
 
     @property
     def typecast(self) -> bool | None:
@@ -433,6 +469,8 @@ class EnumerationMetaClass(type):
         raises: bool = None,
         flags: bool = None,
         start: int = None,
+        steps: int = None,
+        times: int = None,
         typecast: bool = None,
         **kwargs,
     ) -> dict:
@@ -443,7 +481,7 @@ class EnumerationMetaClass(type):
         any other keyword arguments that are included in the class signature call."""
 
         logger.debug(
-            "[EnumerationMetaClass] %s.__prepare__(name: %s, bases: %s, unique: %s, aliased: %s, overwritable: %s, subclassable: %s, removable: %s, raises: %s, flags: %s, start: %s, typecast: %s, kwargs: %s)",
+            "[EnumerationMetaClass] %s.__prepare__(name: %s, bases: %s, unique: %s, aliased: %s, overwritable: %s, subclassable: %s, removable: %s, raises: %s, flags: %s, start: %s, steps: %s, times: %s, typecast: %s, kwargs: %s)",
             name,
             name,
             bases,
@@ -455,6 +493,8 @@ class EnumerationMetaClass(type):
             raises,
             flags,
             start,
+            steps,
+            times,
             typecast,
             kwargs,
         )
@@ -512,9 +552,27 @@ class EnumerationMetaClass(type):
                 "The 'start' argument, if specified, must have a positive integer value!"
             )
 
+        if steps is None:
+            pass
+        elif isinstance(steps, int) and steps >= 1:
+            pass
+        else:
+            raise TypeError(
+                "The 'steps' argument, if specified, must have a positive integer value!"
+            )
+
+        if times is None:
+            pass
+        elif isinstance(times, int) and times >= 1:
+            pass
+        else:
+            raise TypeError(
+                "The 'times' argument, if specified, must have a positive integer value!"
+            )
+
         # Configure the auto() class for subsequent use, resetting the sequence, setting
         # the new start value, and whether values should be flag values (powers of 2)
-        auto.configure(start=start, flags=flags)
+        auto.configure(start=start, steps=steps, times=times, flags=flags)
 
         return dict()
 
@@ -529,6 +587,8 @@ class EnumerationMetaClass(type):
         raises: bool = None,  # False
         flags: bool = None,  # False
         start: int = None,  # None
+        steps: int = None,  # None
+        times: int = None,  # None
         typecast: bool = None,  # True
         **kwargs,
     ):
@@ -595,6 +655,20 @@ class EnumerationMetaClass(type):
                 "The 'start' argument, if specified, must have a positive integer value!"
             )
 
+        if steps is None:
+            pass
+        elif not (isinstance(steps, int) and steps >= 0):
+            raise TypeError(
+                "The 'steps' argument, if specified, must have a positive integer value!"
+            )
+
+        if times is None:
+            pass
+        elif not (isinstance(times, int) and times >= 0):
+            raise TypeError(
+                "The 'times' argument, if specified, must have a positive integer value!"
+            )
+
         if typecast is None:
             pass
         elif not isinstance(typecast, bool):
@@ -611,6 +685,8 @@ class EnumerationMetaClass(type):
             raises=raises,
             flags=flags,
             start=start,
+            steps=steps,
+            times=times,
             typecast=typecast,
         )
 
@@ -689,6 +765,12 @@ class EnumerationMetaClass(type):
                             " >>> start        => %s", base_configuration.start
                         )
                         logger.debug(
+                            " >>> steps        => %s", base_configuration.steps
+                        )
+                        logger.debug(
+                            " >>> times        => %s", base_configuration.times
+                        )
+                        logger.debug(
                             " >>> typecast     => %s", base_configuration.typecast
                         )
 
@@ -730,6 +812,12 @@ class EnumerationMetaClass(type):
                             " >>> (updated) start        => %s", configuration.start
                         )
                         logger.debug(
+                            " >>> (updated) steps        => %s", configuration.steps
+                        )
+                        logger.debug(
+                            " >>> (updated) times        => %s", configuration.times
+                        )
+                        logger.debug(
                             " >>> (updated) typecast     => %s", configuration.typecast
                         )
 
@@ -764,6 +852,8 @@ class EnumerationMetaClass(type):
             raises=False,
             flags=False,
             start=1,
+            steps=1,
+            times=None,
             typecast=True,
         )
 
@@ -781,6 +871,8 @@ class EnumerationMetaClass(type):
         logger.debug(" >>> (after defaults) raises       => %s", configuration.raises)
         logger.debug(" >>> (after defaults) flags        => %s", configuration.flags)
         logger.debug(" >>> (after defaults) start        => %s", configuration.start)
+        logger.debug(" >>> (after defaults) steps        => %s", configuration.steps)
+        logger.debug(" >>> (after defaults) times        => %s", configuration.times)
         logger.debug(" >>> (after defaults) typecast     => %s", configuration.typecast)
 
         # Iterate over the class attributes, looking for any enumeration options
@@ -931,6 +1023,9 @@ class EnumerationMetaClass(type):
         logger.debug(" >>> removable     => %s", configuration.removable)
         logger.debug(" >>> raises        => %s", configuration.raises)
         logger.debug(" >>> flags         => %s", configuration.flags)
+        logger.debug(" >>> start         => %s", configuration.start)
+        logger.debug(" >>> steps         => %s", configuration.steps)
+        logger.debug(" >>> times         => %s", configuration.times)
         logger.debug(" >>> typecast      => %s", configuration.typecast)
 
         # Store the enumeration class configuration options for future reference
@@ -1029,6 +1124,7 @@ class EnumerationMetaClass(type):
         elif self._enumerations and name in self._enumerations:
             return self._enumerations[name]
         else:
+            # EnumerationOptionError subclasses AttributeError so we adhere to convention
             raise EnumerationOptionError(
                 "The '%s' enumeration class, has no '%s' enumeration option nor annotation property!"
                 % (self.__name__, name)
@@ -1480,34 +1576,44 @@ class Enumeration(metaclass=EnumerationMetaClass):
         equals: bool = False
 
         if isinstance(other, Enumeration):
-            return self is other
-
-        for attribute, enumeration in self._enumerations.items():
-            # logger.info("%s(%s).__eq__(other: %s) enumeration => %s" % (self.__class__.__name__, self, other, enumeration))
-
-            if enumeration.value == other:
-                equals = True
-                break
-            elif enumeration.name == other:
-                equals = True
-                break
+            equals = self is other
+        elif self.name == other:
+            equals = True
+        elif self.value == other:
+            equals = True
 
         return equals
 
     def __getattr__(self, name) -> object:
+        """The '__getattr__' method provides support for accessing attribute values that
+        have been assigned to the current enumeration option. If a matching attribute can
+        be found, its value will be returned, otherwise an exception will be raised."""
+
         logger.debug("%s.__getattr__(name: %s)", self.__class__.__name__, name)
 
-        if name.startswith("_") or name in self.__class__._special:
+        if name.startswith("_") or name in self.__class__._special or name in dir(self):
             return object.__getattribute__(self, name)
         elif self._enumerations and name in self._enumerations:
             return self._enumerations[name]
         elif self._annotations and name in self._annotations:
             return self._annotations[name]
         else:
+            # EnumerationOptionError subclasses AttributeError so we adhere to convention
             raise EnumerationOptionError(
                 "The '%s' enumeration class, has no '%s' enumeration option nor annotation property!"
                 % (self.__class__.__name__, name)
             )
+
+    def get(self, name: str, default: object = None) -> object | None:
+        """The 'get' method provides support for accessing annotation values that may
+        have been assigned to the current enumeration option. If a matching annotation
+        can be found, its value will be returned, otherwise the default value will be
+        returned, which defaults to None, but may be specified as any value."""
+
+        if name in self._annotations:
+            return self._annotations[name]
+        else:
+            return default
 
     @property
     def enumeration(self) -> Enumeration:
@@ -1583,6 +1689,15 @@ class EnumerationInteger(int, Enumeration):
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
 
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (int, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
+
 
 class EnumerationFloat(float, Enumeration):
     """An Enumeration subclass where all values are float values."""
@@ -1626,6 +1741,15 @@ class EnumerationComplex(complex, Enumeration):
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
 
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (float, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
+
 
 class EnumerationString(str, Enumeration):
     """An Enumeration subclass where all values are string values."""
@@ -1649,6 +1773,15 @@ class EnumerationString(str, Enumeration):
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
 
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (str, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
+
 
 class EnumerationBytes(bytes, Enumeration):
     """An Enumeration subclass where all values are bytes values."""
@@ -1668,6 +1801,15 @@ class EnumerationBytes(bytes, Enumeration):
 
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
+
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (bytes, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
 
 
 class EnumerationTuple(tuple, Enumeration):
@@ -1689,6 +1831,15 @@ class EnumerationTuple(tuple, Enumeration):
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
 
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (tuple, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
+
 
 class EnumerationSet(set, Enumeration):
     """An Enumeration subclass where all values are set values."""
@@ -1709,6 +1860,15 @@ class EnumerationSet(set, Enumeration):
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
 
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (set, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
+
 
 class EnumerationList(list, Enumeration):
     """An Enumeration subclass where all values are list values."""
@@ -1728,6 +1888,15 @@ class EnumerationList(list, Enumeration):
 
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
+
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (list, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
 
 
 class EnumerationDictionary(dict, Enumeration):
@@ -1751,6 +1920,15 @@ class EnumerationDictionary(dict, Enumeration):
 
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
+
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (dict, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
 
 
 class EnumerationFlag(int, Enumeration):
@@ -1892,6 +2070,15 @@ class EnumerationFlag(int, Enumeration):
 
     def __repr__(self) -> str:
         return Enumeration.__repr__(self)
+
+    def __hash__(self) -> id:
+        return super().__hash__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (int, self.__class__)):
+            return super().__eq__(other)
+        else:
+            return Enumeration.__eq__(self, other)
 
     def __or__(self, other: EnumerationFlag):  # called for: "a | b" (bitwise or)
         """Support performing a bitwise or between the current EnumerationFlag

--- a/tests/test_extensible_enums.py
+++ b/tests/test_extensible_enums.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import types
 
 import enumerific
 
@@ -815,6 +816,23 @@ def test_extensible_enum_subclassing_with_duplicate_non_unique_value():
     # Note that although VIOLET and PURPLE share the same value (6) they are not aliases
     assert not Colors.VIOLET is Colors.PURPLE
     assert not Colors.PURPLE is Colors.VIOLET
+
+
+def test_extensible_enum_options():
+    class Colors(Enumeration):
+        RED = 1
+        GREEN = 2
+        BLUE = 3
+
+    options = Colors.options()
+
+    assert isinstance(options, types.MappingProxyType)
+
+    assert len(options) == 3
+
+    for name, option in options.items():
+        assert isinstance(option.name, str)
+        assert isinstance(option.value, int)
 
 
 def test_extensible_enum_subclassing_disabled_exception():


### PR DESCRIPTION
Added support for defining `steps` and `times` via the `Enumeration` class constructor; added `steps` and `times` handling to the `EnumerationConfiguration` class.

Improved enumeration option equality comparison.

Improved access to annotation and attribute values on `Enumeration` class instances.

Added the option to reconcile enumeration option values caselessly via the optional `caselessly` keyword argument.

Added the `.aliases` property to return a list of the enumeration options which are aliases for the current enumeration option.

Added the `options()` method to return a `MappingProxy` for the enumeration options to provide another way to access and iterate through the options, and for parity with the Enumerific library’s subclassed standard library `Enum` class, which also offers an `options()` method that returns a `MappingProxy` for the enumeration options. Added a unit test for the `options()` method.

Updated the `README` file with information about the Enumerific library’s `Enumeration` class and examples of its usage.